### PR TITLE
changes that made flux streaming work

### DIFF
--- a/cmd/function-sidecar.go
+++ b/cmd/function-sidecar.go
@@ -23,15 +23,15 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/Shopify/sarama"
 	"github.com/bsm/sarama-cluster"
-	"gopkg.in/Shopify/sarama.v1"
 
 	"flag"
 	dispatch "github.com/projectriff/function-sidecar/pkg/dispatcher"
 	"github.com/projectriff/function-sidecar/pkg/dispatcher/grpc"
 	"github.com/projectriff/function-sidecar/pkg/dispatcher/http"
 	"github.com/projectriff/function-sidecar/pkg/dispatcher/stdio"
-	"github.com/projectriff/function-sidecar/pkg/message"
+	"github.com/projectriff/function-sidecar/pkg/wireformat"
 	"strings"
 )
 
@@ -58,9 +58,11 @@ func init() {
 	flag.StringVar(&protocol, "protocol", "", "dispatcher protocol to use. One of [http, grpc, stdio]")
 }
 
+const CorrelationId = "correlationId"
+
 // PropagatedHeaders is the set of header names that will be copied from the incoming message
 // to the outgoing message
-var PropagatedHeaders = []string{"correlationId"}
+var PropagatedHeaders = []string{CorrelationId}
 
 func main() {
 
@@ -113,40 +115,67 @@ func main() {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, os.Kill)
 
+	go func() {
+		for {
+			select {
+			// Incoming message
+			case msg, open := <-consumer.Messages():
+				if open {
+					messageIn, err := wireformat.FromKafka(msg)
+					fmt.Fprintf(os.Stdout, ">>> %s\n", messageIn)
+					if err != nil {
+						log.Printf("Error receiving message from Kafka: %v", err)
+						break
+					}
+					strPayload := string(messageIn.Payload.([]byte))
+					dMessage := dispatch.Message{Payload: strPayload, Headers: messageIn.Headers}
+					dispatcher.Input() <- dMessage
+					consumer.MarkOffset(msg, "") // mark message as processed
+				} else {
+					// Kafka closed
+					log.Print("Exiting Kafka Consumer loop")
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			// Result message
+			case resultMsg, open := <-dispatcher.Output(): // Make sure to drain channel even if output==""
+				if open {
+
+					if output != "" {
+						messageOut := dispatch.Message{Payload: []byte(resultMsg.Payload.(string)), Headers: resultMsg.Headers}
+						fmt.Fprintf(os.Stdout, "<<< %s\n", messageOut)
+						outMessage, err := wireformat.ToKafka(messageOut)
+						if err != nil {
+							log.Printf("Error encoding message: %v", err)
+							break
+						}
+						outMessage.Topic = output
+						select {
+							case producer.Input() <- outMessage:
+						}
+					} else {
+						fmt.Fprintf(os.Stdout, "=== Not sending function return value as function did not provide an output channel. Raw result = %s\n", resultMsg)
+					}
+				} else {
+					log.Print("Exiting Kafka Producer loop")
+					return
+				}
+			}
+		}
+	}()
+
 	// consume messages, watch signals
 	for {
 		select {
-		case msg, ok := <-consumer.Messages():
-			if ok {
-				messageIn, err := message.ExtractMessage(msg.Value)
-				fmt.Fprintf(os.Stdout, "<<< %s\n", messageIn)
-				if err != nil {
-					log.Printf("Error receiving message from Kafka: %v", err)
-					break
-				}
-				strPayload := string(messageIn.Payload.([]byte))
-				dispatched, resultHeaders, err := dispatcher.Dispatch(strPayload, messageIn.Headers)
-				if err != nil {
-					log.Printf("Error dispatching message: %v", err)
-					break
-				}
-				if output != "" {
-					outHeaders := propagateHeaders(messageIn.Headers, resultHeaders)
-					messageOut := message.Message{Payload: []byte(dispatched.(string)), Headers: outHeaders}
-					bytesOut, err := message.EncodeMessage(messageOut)
-					fmt.Fprintf(os.Stdout, ">>> %s\n", messageOut)
-					if err != nil {
-						log.Printf("Error encoding message: %v", err)
-						break
-					}
-					outMessage := &sarama.ProducerMessage{Topic: output, Value: sarama.ByteEncoder(bytesOut)}
-					producer.Input() <- outMessage
-				} else {
-					fmt.Fprintf(os.Stdout, "=== Not sending function return value as function did not provide an output channel. Raw result = %s\n", dispatched)
-				}
-				consumer.MarkOffset(msg, "") // mark message as processed
-			}
+		// Request for shutdown
 		case <-signals:
+			close(dispatcher.Input())
 			return
 		}
 	}
@@ -171,11 +200,11 @@ func propagateHeaders(incomingHeaders dispatch.Headers, resultHeaders dispatch.H
 func createDispatcher(protocol string) dispatch.Dispatcher {
 	switch protocol {
 	case "http":
-		return http.NewHttpDispatcher()
+		return dispatch.NewWrapper(http.NewHttpDispatcher())
 	case "stdio":
-		return stdio.NewStdioDispatcher()
+		return dispatch.NewWrapper(stdio.NewStdioDispatcher())
 	case "grpc":
-		return grpc.NewGrpcDispatcher()
+		return dispatch.NewWrapper(grpc.NewGrpcDispatcher())
 	default:
 		panic("Unsupported Dispatcher " + protocol)
 	}

--- a/cmd/function-sidecar.go
+++ b/cmd/function-sidecar.go
@@ -158,7 +158,7 @@ func main() {
 				if open {
 
 					if output != "" {
-						messageOut := dispatch.Message{Payload: []byte(resultMsg.Payload.(string)), Headers: resultMsg.Headers}
+						messageOut := dispatch.Message{Payload: resultMsg.Payload, Headers: resultMsg.Headers}
 						fmt.Fprintf(os.Stdout, "<<< %s\n", messageOut)
 						outMessage, err := wireformat.ToKafka(messageOut)
 						if err != nil {

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -16,11 +16,34 @@
 
 package dispatcher
 
-type Dispatcher interface {
+import "fmt"
+
+type OldDispatcher interface {
 	Dispatch(in interface{}, headers Headers) (interface{}, Headers, error)
 }
 
+type Dispatcher interface {
+
+	Input() chan<- Message
+
+	Output() <-chan Message
+}
+
 type Headers map[string]interface{}
+
+type Message struct {
+	Payload interface{}
+	Headers Headers
+}
+
+func (msg Message) String() string {
+	switch msg.Payload.(type) {
+	case []byte:
+		return fmt.Sprintf("Message{%v, %v}", string(msg.Payload.([]byte)), msg.Headers)
+	default:
+		return fmt.Sprintf("Message{%v, %v}", msg.Payload, msg.Headers)
+	}
+}
 
 func (h Headers) GetOrDefault(key string, value interface{}) interface{} {
 	if v, ok := h[key] ; ok {

--- a/pkg/dispatcher/grpc/grpc.go
+++ b/pkg/dispatcher/grpc/grpc.go
@@ -43,7 +43,7 @@ func (this grpcDispatcher) Dispatch(in interface{}, headers dispatcher.Headers) 
 	return reply.GetBody(), nil, nil
 }
 
-func NewGrpcDispatcher() dispatcher.Dispatcher {
+func NewGrpcDispatcher() dispatcher.OldDispatcher {
 	context, _ := context.WithTimeout(context.Background(), 60 * time.Second)
 	conn, err := grpc.DialContext(context, "localhost:10382", grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {

--- a/pkg/dispatcher/http/http.go
+++ b/pkg/dispatcher/http/http.go
@@ -80,7 +80,7 @@ func flatten(httpHeaders http.Header) dispatcher.Headers {
 	return result
 }
 
-func NewHttpDispatcher() dispatcher.Dispatcher {
+func NewHttpDispatcher() dispatcher.OldDispatcher {
 	attemptDial := func() error {
 		log.Println("Waiting for function to accept connection on localhost:8080")
 		_, err := net.Dial("tcp", "localhost:8080")

--- a/pkg/dispatcher/pipes/pipes.go
+++ b/pkg/dispatcher/pipes/pipes.go
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipes
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/projectriff/function-sidecar/pkg/dispatcher"
+	"log"
+	"os"
+	"strings"
+	"syscall"
+)
+
+const (
+	INPUT_PIPE  = "/pipes/input"
+	OUTPUT_PIPE = "/pipes/output"
+)
+
+type pipesDispatcher struct {
+	input  chan<- dispatcher.Message
+	output <-chan dispatcher.Message
+}
+
+func (this pipesDispatcher) Input() chan<- dispatcher.Message {
+	return this.input
+}
+
+func (this pipesDispatcher) Output() <-chan dispatcher.Message {
+	return this.output
+}
+
+func NewPipesDispatcher() (dispatcher.Dispatcher, error) {
+	fmt.Println("Creating new pipes Dispatcher")
+	err := syscall.Mkfifo(INPUT_PIPE, 0666)
+	if err != nil {
+		err = os.Remove(INPUT_PIPE)
+		if err != nil {
+			return nil, err
+		}
+		err = syscall.Mkfifo(INPUT_PIPE, 0666)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		fmt.Printf("Created %v\n", INPUT_PIPE)
+	}
+	err = syscall.Mkfifo(OUTPUT_PIPE, 0666)
+	if err != nil {
+		err = os.Remove(OUTPUT_PIPE)
+		if err != nil {
+			return nil, err
+		}
+		err = syscall.Mkfifo(OUTPUT_PIPE, 0666)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		fmt.Printf("Created %v\n", OUTPUT_PIPE)
+	}
+
+	outfile, err := os.OpenFile(INPUT_PIPE, os.O_RDWR, os.ModeNamedPipe)
+	if err != nil {
+		panic(err)
+	}
+	writer := bufio.NewWriter(outfile)
+	infile, err := os.OpenFile(OUTPUT_PIPE, os.O_RDWR, os.ModeNamedPipe)
+	if err != nil {
+		panic(err)
+	}
+	reader := bufio.NewReader(infile)
+
+	i := make(chan dispatcher.Message, 100) // TODO buffered
+	o := make(chan dispatcher.Message, 100)
+
+	go func() {
+		for {
+			select {
+			case in, open := <-i:
+				fmt.Printf("Got a msg %v", in)
+				if open {
+					err := writeMessage(writer, in)
+					if err != nil {
+						log.Printf("Error writing to %v: %v", INPUT_PIPE, err)
+						break
+					}
+				} else {
+					close(o)
+					log.Print("Shutting down pipes dispatcher")
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			msg, err := readMessage(reader)
+			if err != nil {
+				o <- *msg
+			}
+		}
+	}()
+
+	return pipesDispatcher{input: i, output: o}, nil
+}
+
+func readMessage(reader *bufio.Reader) (*dispatcher.Message, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	} else if line != "#headers\n" {
+		return nil, errors.New("Unexpected first line of message: " + line)
+	}
+
+	message := dispatcher.Message{}
+	for line, err = reader.ReadString('\n'); line != "#payload\n"; line, err = reader.ReadString('\n') {
+		if err != nil {
+			return nil, err
+		}
+		line = line[0 : len(line)-1] // drop CR
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			return nil, errors.New("Malformed header line: " + line)
+		}
+		message.Headers[kv[0]] = kv[1]
+	}
+
+	payload := make([]byte, 0)
+	for line, err = reader.ReadString('\n'); line != "#end\n"; line, err = reader.ReadString('\n') {
+		if err != nil {
+			return nil, err
+		}
+		payload = append(payload, ([]byte(line))...)
+	}
+	// Strip last CR
+	payload = payload[0 : len(payload)-1]
+
+	message.Payload = payload
+	return &message, nil
+}
+
+func writeMessage(writer *bufio.Writer, in dispatcher.Message) error {
+	_, err := writer.WriteString("#headers\n")
+	if err != nil {
+		return err
+	}
+	for k, v := range in.Headers {
+		_, err = writer.WriteString(k + "=" + v.(string) + "\n")
+		if err != nil {
+			return err
+		}
+	}
+	_, err = writer.WriteString("#payload\n")
+	if err != nil {
+		return err
+	}
+	_, err = writer.WriteString(in.Payload.(string))
+	if err != nil {
+		return err
+	}
+	_, err = writer.WriteString("#end\n")
+	if err != nil {
+		return err
+	}
+	err = writer.Flush()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/dispatcher/stdio/stdio.go
+++ b/pkg/dispatcher/stdio/stdio.go
@@ -72,8 +72,10 @@ func NewStdioDispatcher() (dispatcher.OldDispatcher, error) {
 	fmt.Println("Creating new stdio Dispatcher")
 	err := syscall.Mkfifo(INPUT_PIPE, 0666)
 	if err != nil {
+		log.Printf("error creating input pipe: %v", err)
 		err = os.Remove(INPUT_PIPE)
 		if err != nil {
+			log.Printf("error removing input pipe: %v", err)
 			return nil, err
 		}
 		err = syscall.Mkfifo(INPUT_PIPE, 0666)

--- a/pkg/dispatcher/stdio/stdio.go
+++ b/pkg/dispatcher/stdio/stdio.go
@@ -56,17 +56,43 @@ func (this stdioDispatcher) Dispatch(in interface{}, headers dispatcher.Headers)
 	return line[0 : len(line)-1], nil, nil
 }
 
-func NewStdioDispatcher() dispatcher.OldDispatcher {
+func (this stdioDispatcher) Close() error {
+	err1 := os.Remove(INPUT_PIPE)
+	err2 := os.Remove(OUTPUT_PIPE)
+	log.Printf("err1 = %v"  , err1)
+	log.Printf("err2 = %v"  , err2)
+	if err1 == nil {
+		return err2
+	} else {
+		return err1
+	}
+}
+
+func NewStdioDispatcher() (dispatcher.OldDispatcher, error) {
 	fmt.Println("Creating new stdio Dispatcher")
 	err := syscall.Mkfifo(INPUT_PIPE, 0666)
 	if err != nil {
-		panic(err)
+		err = os.Remove(INPUT_PIPE)
+		if err != nil {
+			return nil, err
+		}
+		err = syscall.Mkfifo(INPUT_PIPE, 0666)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		fmt.Printf("Created %v\n", INPUT_PIPE)
 	}
 	err = syscall.Mkfifo(OUTPUT_PIPE, 0666)
 	if err != nil {
-		panic(err)
+		err = os.Remove(OUTPUT_PIPE)
+		if err != nil {
+			return nil, err
+		}
+		err = syscall.Mkfifo(OUTPUT_PIPE, 0666)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		fmt.Printf("Created %v\n", OUTPUT_PIPE)
 	}
@@ -75,7 +101,7 @@ func NewStdioDispatcher() dispatcher.OldDispatcher {
 
 	outfile, err := os.OpenFile(INPUT_PIPE, os.O_RDWR, os.ModeNamedPipe)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	result.writer = bufio.NewWriter(outfile)
 	infile, err := os.OpenFile(OUTPUT_PIPE, os.O_RDWR, os.ModeNamedPipe)
@@ -84,5 +110,5 @@ func NewStdioDispatcher() dispatcher.OldDispatcher {
 	}
 	result.reader = bufio.NewReader(infile)
 
-	return result
+	return result, nil
 }

--- a/pkg/dispatcher/stdio/stdio.go
+++ b/pkg/dispatcher/stdio/stdio.go
@@ -56,7 +56,7 @@ func (this stdioDispatcher) Dispatch(in interface{}, headers dispatcher.Headers)
 	return line[0 : len(line)-1], nil, nil
 }
 
-func NewStdioDispatcher() dispatcher.Dispatcher {
+func NewStdioDispatcher() dispatcher.OldDispatcher {
 	fmt.Println("Creating new stdio Dispatcher")
 	err := syscall.Mkfifo(INPUT_PIPE, 0666)
 	if err != nil {

--- a/pkg/dispatcher/wrapper.go
+++ b/pkg/dispatcher/wrapper.go
@@ -38,6 +38,9 @@ var PropagatedHeaders = []string{"correlationId"}
 
 // copy headers from incomingMessage that need to be propagated into resultMessage.Headers
 func propagateHeaders(incomingMessage *Message, resultMessage *Message) {
+	if resultMessage.Headers == nil {
+		resultMessage.Headers = make(map[string]interface{})
+	}
 	for _, h := range PropagatedHeaders {
 		if value, ok := incomingMessage.Headers[h]; ok {
 			resultMessage.Headers[h] = value

--- a/pkg/dispatcher/wrapper.go
+++ b/pkg/dispatcher/wrapper.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dispatcher
+
+import "log"
+
+type wrapper struct {
+	old    OldDispatcher
+	input  chan<- Message
+	output <-chan Message
+}
+
+func (w wrapper) Input() chan<- Message {
+	return w.input
+}
+
+func (w wrapper) Output() <-chan Message {
+	return w.output
+}
+
+// PropagatedHeaders is the set of header names that will be copied from the incoming message
+// to the outgoing message
+var PropagatedHeaders = []string{"correlationId"}
+
+// copy headers from incomingMessage that need to be propagated into resultMessage.Headers
+func propagateHeaders(incomingMessage *Message, resultMessage *Message) {
+	for _, h := range PropagatedHeaders {
+		if value, ok := incomingMessage.Headers[h]; ok {
+			resultMessage.Headers[h] = value
+		}
+	}
+}
+
+func NewWrapper(old OldDispatcher) wrapper {
+	i := make(chan Message)
+	o := make(chan Message)
+
+	go func() {
+		for {
+			select {
+			case in, open := <-i:
+				if open {
+					log.Printf("Wrapper received %v\n", in)
+					payload, headers, err := old.Dispatch(in.Payload, in.Headers)
+					if err != nil {
+						log.Printf("Error calling old dispatcher %v\n", err)
+					}
+					message := Message{Payload: payload, Headers: headers}
+					propagateHeaders(&in, &message)
+					log.Printf("Wrapper about to forward %v\n", message)
+					o <- message
+				} else {
+					close(o)
+					log.Print("Shutting down wrapper")
+					return
+				}
+			}
+		}
+	}()
+
+	return wrapper{old: old, input: i, output: o}
+}

--- a/pkg/dispatcher/wrapper.go
+++ b/pkg/dispatcher/wrapper.go
@@ -45,7 +45,7 @@ func propagateHeaders(incomingMessage *Message, resultMessage *Message) {
 	}
 }
 
-func NewWrapper(old OldDispatcher) wrapper {
+func NewWrapper(old OldDispatcher) (wrapper, error) {
 	i := make(chan Message)
 	o := make(chan Message)
 
@@ -72,5 +72,5 @@ func NewWrapper(old OldDispatcher) wrapper {
 		}
 	}()
 
-	return wrapper{old: old, input: i, output: o}
+	return wrapper{old: old, input: i, output: o}, nil
 }

--- a/pkg/wireformat/wireformat.go
+++ b/pkg/wireformat/wireformat.go
@@ -50,9 +50,6 @@ func extractMessage(bytes []byte) (dispatcher.Message, error) {
 	offset++
 
 	headers := make(map[string]interface{}, headerCount)
-	if headerCount == 0 {
-		headers = nil
-	}
 	for i := byte(0); i < headerCount; i = i + 1 {
 		len := uint32(bytes[offset])
 		offset++

--- a/pkg/wireformat/wireformat_test.go
+++ b/pkg/wireformat/wireformat_test.go
@@ -14,34 +14,35 @@
  * limitations under the License.
  */
 
-package message
+package wireformat
 
 import (
 	"testing"
 	"reflect"
+	"github.com/projectriff/function-sidecar/pkg/dispatcher"
 )
 
 func TestEmptyMessage(t *testing.T) {
-	msg := Message{}
+	msg := dispatcher.Message{}
 	encodeThenDecode(msg, t)
 }
 
 func TestMessageWithOnlyPayload(t *testing.T) {
-	msg := Message{Payload: []byte("Hello")}
+	msg := dispatcher.Message{Payload: []byte("Hello")}
 	encodeThenDecode(msg, t)
 }
 
 func TestMessageWithOnlyHeaders(t *testing.T) {
-	msg := Message{Headers: map[string]interface{}{"key1":"value1", "k2":18.0}}
+	msg := dispatcher.Message{Headers: map[string]interface{}{"key1":"value1", "k2":18.0}}
 	encodeThenDecode(msg, t)
 }
 
-func encodeThenDecode(msg Message, t *testing.T) {
-	bytes, err := EncodeMessage(msg)
+func encodeThenDecode(msg dispatcher.Message, t *testing.T) {
+	bytes, err := encodeMessage(msg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	msg2, err := ExtractMessage(bytes)
+	msg2, err := extractMessage(bytes)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
obviously a lot of cleanup still required, but this branch works with:

1. this `function-controller` PR branch that adds volumes for "pipes" protocol functions: https://github.com/projectriff/function-controller/pull/8
2. this `java-function-invoker` branch that adds the file binder: https://github.com/projectriff/java-function-invoker/pull/4
3. the counter function on this branch of the s1p demo that uses a window operation on a `Flux` (follow the README): https://github.com/markfisher/s1p2017-faas-demo/tree/pipes-dispatcher/functions/counter
